### PR TITLE
components/last_login: work around parsing ambiguities with IPv6 addresses

### DIFF
--- a/src/components/last_login.rs
+++ b/src/components/last_login.rs
@@ -49,7 +49,7 @@ fn parse_entry(line: &str) -> Result<Entry, LastLoginError> {
 
     Ok(Entry {
         username: items[0],
-        location: items[2],
+        location: items[1],
         start_time: items[3],
         end_time: items[4],
     })
@@ -94,12 +94,10 @@ pub fn disp_last_login(
         println!("{}{}:", " ".repeat(INDENT_WIDTH as usize), username);
 
         // Use `last` command to get last logins
-        let executable = "last";
-        let output = BetterCommand::new(executable)
+        let output = BetterCommand::new("bash")
             // Sometimes last doesn't show location otherwise for some reason
-            .arg("--ip")
-            .arg("--time-format=iso")
-            .arg(&username)
+            .arg("-c")
+            .arg(format!("last --time-format iso --ip {} | awk '{{ out=$1\"  \"$3; $3=\"\"; gsub(/ still/, \"  still\", $0); print out\"  \"$0; }}'", &username))
             .check_status_and_get_output_string()?;
 
         // Split lines and take desigred number


### PR DESCRIPTION
When connecting to your servers using IPv6 the output of `last(1)` looks
somewhat similar to this:

    root     pts/0        2a01:4f8:c2c:e61 2021-03-13T23:30:52+00:00 - 2021-03-13T23:30:53+00:00  (00:00)
    root     pts/0        2a01:4f8:c2c:e61 2021-03-13T21:39:16+00:00 - 2021-03-13T21:39:27+00:00  (00:00)

This is a problem for us since the `parse_entry` function expects two
spaces between values which is obviously not the case anymore between
the (truncated) IPv6 address and the date right next to it. Due to that,
the resulting `motd`-file usually looked like this for me:

    Last Login:
      root:
    Last login error: Failed to parse output from `last`

By looking at the `util-linux` source-code I realized that this is a
limitation of `last(1)` itself as it shows 16 characters for the IP and
then a single space before the date[1]:

    "%-8.*s %-12.12s %-16.*s %-*.*s %-*.*s %s\n",

I figured that it's more efficient now to implement a workaround in
`rust-motd` itself for me by ensuring two spaces between each value
using `awk(1)`.

[1] https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/login-utils/last.c?h=stable/v2.37#n540