### PR TITLE
Fix build on Darwin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if let Some(memory) = config.memory {
                 disp_memory(memory, &config.global, &sys, bar_size_hint) // TODO:
-                    .unwrap_or_else(|err| println!("Filesystem error: {}", err));
+                    .unwrap_or_else(|err| println!("Memory error: {}", err));
                 println!();
             }
 


### PR DESCRIPTION
Fixes #20 

- Conditionally ignore memory stats on non linux/android platforms. Darwin is not supported by systemstat (https://github.com/unrelentingtech/systemstat/issues/73).
- Fixed a error output string for MemoryError

Thanks @amfl