### PR TITLE
filesystems: Use IndexMap instead of HashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +524,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -659,7 +671,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1064,6 +1087,7 @@ dependencies = [
  "clap 4.2.7",
  "docker-api",
  "humantime",
+ "indexmap 2.7.0",
  "itertools",
  "last-rs",
  "lazy_static",
@@ -1177,7 +1201,7 @@ dependencies = [
  "base64",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
  "serde_with_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ docker-api = { version = "0.12.0" }
 tokio = { version = "1.14.0", features = ["full"] }
 async-trait = "0.1.57"
 clap ={ version = "4.2.7", features = ["unstable-doc"]}
+indexmap = { version = "2.7.0", features = ["serde"] }
 
 [package.metadata.bundle]

--- a/src/components/filesystem.rs
+++ b/src/components/filesystem.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use bytesize::ByteSize;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use std::cmp;
-use std::collections::HashMap;
 use std::iter;
 use systemstat::{Filesystem, Platform, System};
 use termion::{color, style};
@@ -18,7 +18,7 @@ const HEADER: [&str; 6] = ["Filesystems", "Device", "Mount", "Type", "Used", "To
 /// A container for the mount points specified in the configuration file
 #[derive(Clone)]
 pub struct Filesystems {
-    pub mounts: HashMap<String, String>,
+    pub mounts: IndexMap<String, String>,
 }
 
 #[async_trait]
@@ -114,7 +114,7 @@ fn print_row<'a>(items: [&str; 6], column_sizes: impl IntoIterator<Item = &'a us
 }
 
 impl Filesystems {
-    pub fn new(mounts: HashMap<String, String>) -> Self {
+    pub fn new(mounts: IndexMap<String, String>) -> Self {
         Self { mounts }
     }
 
@@ -129,7 +129,7 @@ impl Filesystems {
         }
 
         let mounts = sys.mounts()?;
-        let mounts: HashMap<String, &Filesystem> = mounts
+        let mounts: IndexMap<String, &Filesystem> = mounts
             .iter()
             .map(|fs| (fs.fs_mounted_on.clone(), fs))
             .collect();

--- a/src/components/last_login.rs
+++ b/src/components/last_login.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::{Local, TimeZone};
 use humantime::format_duration;
+use indexmap::IndexMap;
 use last_rs::{get_logins, Enter, Exit, LastError};
-use std::collections::HashMap;
 use std::time::Duration;
 use termion::{color, style};
 use thiserror::Error;
@@ -17,7 +17,7 @@ use crate::constants::INDENT_WIDTH;
 use crate::default_prepare;
 
 pub struct LastLogin {
-    pub users: HashMap<String, usize>,
+    pub users: IndexMap<String, usize>,
 }
 
 #[async_trait]

--- a/src/components/service_status.rs
+++ b/src/components/service_status.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
-use itertools::Itertools;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use termion::{color, style};
 use thiserror::Error;
 
@@ -11,11 +10,11 @@ use crate::constants::INDENT_WIDTH;
 use crate::default_prepare;
 
 pub struct ServiceStatus {
-    pub services: HashMap<String, String>,
+    pub services: IndexMap<String, String>,
 }
 
 pub struct UserServiceStatus {
-    pub services: HashMap<String, String>,
+    pub services: IndexMap<String, String>,
 }
 
 #[async_trait]
@@ -68,7 +67,7 @@ fn get_service_status(service: &str, user: bool) -> Result<String, ServiceStatus
 }
 
 pub fn print_or_error(
-    config: &HashMap<String, String>,
+    config: &IndexMap<String, String>,
     user: bool,
 ) -> Result<(), ServiceStatusError> {
     if config.is_empty() {
@@ -77,7 +76,7 @@ pub fn print_or_error(
 
     let padding = config.keys().map(|x| x.len()).max().unwrap();
 
-    for key in config.keys().sorted() {
+    for key in config.keys() {
         let status = get_service_status(config.get(key).unwrap(), user)?;
 
         let status_color = match status.as_ref() {

--- a/src/components/ssl_certs.rs
+++ b/src/components/ssl_certs.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::{Duration, TimeZone, Utc};
+use indexmap::IndexMap;
 use openssl::x509::X509;
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use termion::{color, style};
@@ -28,7 +28,7 @@ enum SortMethod {
 pub struct SSLCerts {
     #[serde(default)]
     sort_method: SortMethod,
-    certs: HashMap<String, String>,
+    certs: IndexMap<String, String>,
 }
 
 #[async_trait]


### PR DESCRIPTION
Before this change, the order of printed filesystems was different (random) in every invocation. With this change, the order is the same as in the configuration file.